### PR TITLE
Stream 417 genesis backfill

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,11 @@ blocks_history:
 	--profile cosmos \
 	--target $(DBT_TARGET) \
 	--profiles-dir ~/.dbt
+
+tx_history:
+	dbt run \
+	--vars '{"STREAMLINE_INVOKE_STREAMS":True, "STREAMLINE_USE_DEV_FOR_EXTERNAL_TABLES": True}' \
+	-m 1+models/streamline/genesis_backfill/streamline__transactions_genesis_backfill_ch1.sql \
+	--profile cosmos \
+	--target $(DBT_TARGET) \
+	--profiles-dir ~/.dbt

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,40 @@ dbt-console:
 	docker-compose run dbt_console
 
 .PHONY: dbt-console
+
+SHELL := /bin/bash
+
+# set default target
+DBT_TARGET ?= dev
+AWS_LAMBDA_ROLE ?= aws_lambda_cosmos_api_dev
+
+sl-cosmos-api:
+	dbt run-operation create_aws_cosmos_api \
+	--profile cosmos \
+	--target $(DBT_TARGET) \
+	--profiles-dir ~/.dbt/
+
+udfs:
+	dbt run-operation create_udfs \
+	--vars '{"UPDATE_UDFS_AND_SPS":True}' \
+	--profile cosmos \
+	--target $(DBT_TARGET) \
+	--profiles-dir ~/.dbt/
+
+complete:
+	dbt run \
+	--vars '{"STREAMLINE_INVOKE_STREAMS":True, "STREAMLINE_USE_DEV_FOR_EXTERNAL_TABLES": True}' \
+	-m 1+models/silver/streamline/core/complete \
+	--profile cosmos \
+	--target $(DBT_TARGET) \
+	--profiles-dir ~/.dbt
+
+streamline: sl-cosmos-api udfs 
+
+blocks_history:
+	dbt run \
+	--vars '{"STREAMLINE_INVOKE_STREAMS":True, "STREAMLINE_USE_DEV_FOR_EXTERNAL_TABLES": True}' \
+	-m 1+models/streamline/genesis_backfill/streamline__blocks_genesis_backfill_ch1.sql \
+	--profile cosmos \
+	--target $(DBT_TARGET) \
+	--profiles-dir ~/.dbt

--- a/macros/create_udfs.sql
+++ b/macros/create_udfs.sql
@@ -14,7 +14,7 @@
         {{ create_udf_get_cosmos_validators() }}
         {{ create_udf_get_cosmos_generic() }}
         {{ create_udf_get_cosmos_chainhead() }}
-
+        {{ log("CREATING UDFS !!")}}
         {% endset %}
         {% do run_query(sql) %}
     {% endif %}

--- a/macros/streamline/api_integrations.sql
+++ b/macros/streamline/api_integrations.sql
@@ -5,7 +5,14 @@
             'https://z97ik1b2d0.execute-api.us-east-1.amazonaws.com/dev/',
             'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/'
         ) enabled = TRUE;
-{% endset %}
+        {% endset %}
+        {% do run_query(sql) %}
+    {% elif target.name == "dev" %}
+        {% set sql %}
+        CREATE api integration IF NOT EXISTS aws_cosmos_api_dev api_provider = aws_api_gateway api_aws_role_arn = 'arn:aws:iam::490041342817:role/cosmos-api-dev-rolesnowflakeudfsAF733095-1SQ9TX1BQRUE' api_allowed_prefixes = (
+            'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/'
+        ) enabled = TRUE;
+        {% endset %}
         {% do run_query(sql) %}
     {% endif %}
 {% endmacro %}

--- a/macros/streamline/streamline_udfs.sql
+++ b/macros/streamline/streamline_udfs.sql
@@ -5,7 +5,7 @@
     ) returns text api_integration = aws_cosmos_api AS {% if target.name == "prod" %}
         'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/bulk_get_cosmos_blocks'
     {% else %}
-        'https://z97ik1b2d0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_blocks'
+        'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_blocks'
     {%- endif %};
 {% endmacro %}
 
@@ -16,7 +16,7 @@
     ) returns text api_integration = aws_cosmos_api AS {% if target.name == "prod" %}
         'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/bulk_get_cosmos_transactions'
     {% else %}
-        'https://z97ik1b2d0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_transactions'
+        'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_transactions'
     {%- endif %};
 {% endmacro %}
 
@@ -27,7 +27,7 @@
     ) returns text api_integration = aws_cosmos_api AS {% if target.name == "prod" %}
         'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/bulk_get_cosmos_validators'
     {% else %}
-        'https://z97ik1b2d0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_validators'
+        'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_validators'
     {%- endif %};
 {% endmacro %}
 
@@ -38,7 +38,7 @@
     ) returns text api_integration = aws_cosmos_api AS {% if target.name == "prod" %}
         'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/bulk_get_cosmos_generic'
     {% else %}
-        'https://z97ik1b2d0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_generic'
+        'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_generic'
     {%- endif %};
 {% endmacro %}
 
@@ -46,6 +46,6 @@
     CREATE EXTERNAL FUNCTION IF NOT EXISTS streamline.udf_get_cosmos_chainhead() returns variant api_integration = aws_cosmos_api AS {% if target.name == "prod" %}
         'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/get_cosmos_chainhead'
     {% else %}
-        'https://z97ik1b2d0.execute-api.us-east-1.amazonaws.com/dev/get_cosmos_chainhead'
+        'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/get_cosmos_chainhead'
     {%- endif %};
 {% endmacro %}

--- a/macros/streamline/streamline_udfs.sql
+++ b/macros/streamline/streamline_udfs.sql
@@ -2,10 +2,10 @@
     CREATE
     OR REPLACE EXTERNAL FUNCTION streamline.udf_get_cosmos_blocks(
         json variant
-    ) returns text api_integration = aws_cosmos_api AS {% if target.name == "prod" %}
-        'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/bulk_get_cosmos_blocks'
+    ) returns text {% if target.name == "prod" %}
+        api_integration = aws_cosmos_api AS 'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/bulk_get_cosmos_blocks'
     {% else %}
-        'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_blocks'
+        api_integration = aws_cosmos_api_dev AS 'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_blocks'
     {%- endif %};
 {% endmacro %}
 
@@ -13,10 +13,10 @@
     CREATE
     OR REPLACE EXTERNAL FUNCTION streamline.udf_get_cosmos_transactions(
         json variant
-    ) returns text api_integration = aws_cosmos_api AS {% if target.name == "prod" %}
-        'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/bulk_get_cosmos_transactions'
+    ) returns text  {% if target.name == "prod" %}
+        api_integration = aws_cosmos_api AS 'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/bulk_get_cosmos_transactions'
     {% else %}
-        'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_transactions'
+        api_integration = aws_cosmos_api_dev AS 'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_transactions'
     {%- endif %};
 {% endmacro %}
 
@@ -24,10 +24,10 @@
     CREATE
     OR REPLACE EXTERNAL FUNCTION streamline.udf_get_cosmos_validators(
         json variant
-    ) returns text api_integration = aws_cosmos_api AS {% if target.name == "prod" %}
-        'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/bulk_get_cosmos_validators'
+    ) returns text {% if target.name == "prod" %}
+        api_integration = aws_cosmos_api AS 'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/bulk_get_cosmos_validators'
     {% else %}
-        'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_validators'
+        api_integration = aws_cosmos_api_dev AS 'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_validators'
     {%- endif %};
 {% endmacro %}
 
@@ -35,17 +35,18 @@
     CREATE
     OR REPLACE EXTERNAL FUNCTION streamline.udf_get_cosmos_generic(
         json variant
-    ) returns text api_integration = aws_cosmos_api AS {% if target.name == "prod" %}
-        'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/bulk_get_cosmos_generic'
+    ) returns text{% if target.name == "prod" %}
+        api_integration = aws_cosmos_api AS 'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/bulk_get_cosmos_generic'
     {% else %}
-        'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_generic'
+        api_integration = aws_cosmos_api_dev AS 'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/bulk_get_cosmos_generic'
     {%- endif %};
 {% endmacro %}
 
 {% macro create_udf_get_cosmos_chainhead() %}
-    CREATE EXTERNAL FUNCTION IF NOT EXISTS streamline.udf_get_cosmos_chainhead() returns variant api_integration = aws_cosmos_api AS {% if target.name == "prod" %}
-        'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/get_cosmos_chainhead'
+    CREATE EXTERNAL FUNCTION IF NOT EXISTS streamline.udf_get_cosmos_chainhead() 
+    returns variant {% if target.name == "prod" %}
+        api_integration = aws_cosmos_api AS 'https://dazi3rled6.execute-api.us-east-1.amazonaws.com/prod/get_cosmos_chainhead'
     {% else %}
-        'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/get_cosmos_chainhead'
+        api_integration = aws_cosmos_api_dev AS'https://qkwbozz9l0.execute-api.us-east-1.amazonaws.com/dev/get_cosmos_chainhead'
     {%- endif %};
 {% endmacro %}

--- a/models/streamline/genesis_backfill/streamline__blocks_ch1.sql
+++ b/models/streamline/genesis_backfill/streamline__blocks_ch1.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    tags = ['streamline_view']
+) }}
+
+SELECT
+    height as block_number
+FROM
+    TABLE(streamline.udtf_get_base_table(35))
+WHERE
+    height between 0 and 20 

--- a/models/streamline/genesis_backfill/streamline__blocks_ch1.sql
+++ b/models/streamline/genesis_backfill/streamline__blocks_ch1.sql
@@ -6,6 +6,6 @@
 SELECT
     height as block_number
 FROM
-    TABLE(streamline.udtf_get_base_table(35))
+    TABLE(streamline.udtf_get_base_table(200001))
 WHERE
-    height between 0 and 20 
+    height between 0 and 200000

--- a/models/streamline/genesis_backfill/streamline__blocks_ch1.sql
+++ b/models/streamline/genesis_backfill/streamline__blocks_ch1.sql
@@ -6,6 +6,6 @@
 SELECT
     height as block_number
 FROM
-    TABLE(streamline.udtf_get_base_table(200001))
+    TABLE(streamline.udtf_get_base_table(500042))
 WHERE
-    height between 0 and 200000
+    height between 0 and 500042 // https://hub.cosmos.network/main/roadmap/#cosmos-hub-summary

--- a/models/streamline/genesis_backfill/streamline__blocks_ch2.sql
+++ b/models/streamline/genesis_backfill/streamline__blocks_ch2.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    tags = ['streamline_view']
+) }}
+
+SELECT
+    height as block_number
+FROM
+    TABLE(streamline.udtf_get_base_table(2901999))
+WHERE
+    height between 500043 and 2901999 // https://hub.cosmos.network/main/roadmap/#cosmos-hub-summary

--- a/models/streamline/genesis_backfill/streamline__blocks_ch3.sql
+++ b/models/streamline/genesis_backfill/streamline__blocks_ch3.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "view",
+    tags = ['streamline_view']
+) }}
+
+SELECT
+    height as block_number
+FROM
+    TABLE(streamline.udtf_get_base_table(5200790))
+WHERE
+    height between 2902000 and 5200790 // https://hub.cosmos.network/main/roadmap/#cosmos-hub-summary

--- a/models/streamline/genesis_backfill/streamline__blocks_genesis_backfill_ch1.sql
+++ b/models/streamline/genesis_backfill/streamline__blocks_genesis_backfill_ch1.sql
@@ -1,0 +1,19 @@
+{{ config (
+    materialized = "view",
+    post_hook = if_data_call_function(
+        func = "{{this.schema}}.udf_get_cosmos_blocks(object_construct('sql_source', '{{this.identifier}}'))",
+        target = "{{this.schema}}.{{this.identifier}}"
+    )
+) }}
+
+SELECT
+    {{ dbt_utils.generate_surrogate_key(
+        ['block_number']
+    ) }} AS id,
+    block_number
+FROM
+    {{ ref("streamline__blocks_ch1") }}
+WHERE
+    block_number between 0 and 10
+    AND block_number IS NOT NULL
+

--- a/models/streamline/genesis_backfill/streamline__blocks_genesis_backfill_ch1.sql
+++ b/models/streamline/genesis_backfill/streamline__blocks_genesis_backfill_ch1.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_get_cosmos_blocks(object_construct('sql_source', '{{this.identifier}}','sm_node_path','prod/cosmos/allthatnode/mainnet-ch1/rpc'))",
+        func = "{{this.schema}}.udf_get_cosmos_blocks(object_construct('sql_source', '{{this.identifier}}','sm_node_path','prod/cosmos/allthatnode/mainnet-ch1/rpc', 'call_type','non_batch'))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/streamline/genesis_backfill/streamline__blocks_genesis_backfill_ch1.sql
+++ b/models/streamline/genesis_backfill/streamline__blocks_genesis_backfill_ch1.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_get_cosmos_blocks(object_construct('sql_source', '{{this.identifier}}'))",
+        func = "{{this.schema}}.udf_get_cosmos_blocks(object_construct('sql_source', '{{this.identifier}}','sm_node_path','prod/cosmos/allthatnode/mainnet-ch1/rpc'))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}
@@ -14,6 +14,6 @@ SELECT
 FROM
     {{ ref("streamline__blocks_ch1") }}
 WHERE
-    block_number between 0 and 10
+    block_number between 110500 and 110550 
     AND block_number IS NOT NULL
 

--- a/models/streamline/genesis_backfill/streamline__transactions_genesis_backfill_ch1.sql
+++ b/models/streamline/genesis_backfill/streamline__transactions_genesis_backfill_ch1.sql
@@ -1,0 +1,30 @@
+{{ config (
+    materialized = "view",
+    post_hook = if_data_call_function(
+        func = "{{this.schema}}.udf_get_cosmos_transactions(object_construct('sql_source', '{{this.identifier}}','sm_node_path','prod/cosmos/allthatnode/mainnet-ch1/rpc','call_type','non_batch'))",
+        target = "{{this.schema}}.{{this.identifier}}"
+    )
+) }}
+
+SELECT
+    {{ dbt_utils.generate_surrogate_key(
+        ['block_number']
+    ) }} AS id,
+    block_number
+FROM
+    {{ ref("streamline__blocks_ch1") }}
+WHERE
+    block_number between 110610 and 110620 
+    AND block_number IS NOT NULL
+EXCEPT
+SELECT
+    id,
+    block_number
+FROM
+    {{ ref("streamline__complete_transactions") }}
+WHERE
+    block_number between 110500 and 110550 
+    AND block_number IS NOT NULL
+ORDER BY
+    block_number
+    


### PR DESCRIPTION
- Adds make directives to create streamline udfs (from the `cdk` migration)
- Adds `dev` `cdk migrated` `udf integration`
- Adds genesis `udtf` and `ch1-3` `blocks & tx` backfill models
- Adds dynamic node configurability to backfill models via `sm_node_path`
- Adds `call_type` udf param to enable non-batch support for `cosmos hub 1 -3`
